### PR TITLE
chore: vite を 8 系へメジャー更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "@vitejs/plugin-react": "^5.1.4",
                 "eslint": "^9.39.1",
                 "eslint-plugin-react": "^7.37.5",
-                "vite": "^7.3.1",
+                "vite": "^8.0.3",
                 "vite-plugin-singlefile": "^2.3.0",
                 "vitest": "^4.0.18"
             }
@@ -341,6 +341,40 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@emnapi/core": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+            "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/wasi-threads": "1.2.0",
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/runtime": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+            "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@emnapi/wasi-threads": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+            "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
+        },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.27.4",
             "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
@@ -354,6 +388,7 @@
             "os": [
                 "aix"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -371,6 +406,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -388,6 +424,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -405,6 +442,7 @@
             "os": [
                 "android"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -422,6 +460,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -439,6 +478,7 @@
             "os": [
                 "darwin"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -456,6 +496,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -473,6 +514,7 @@
             "os": [
                 "freebsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -490,6 +532,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -507,6 +550,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -524,6 +568,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -541,6 +586,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -558,6 +604,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -575,6 +622,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -592,6 +640,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -609,6 +658,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -626,6 +676,7 @@
             "os": [
                 "linux"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -643,6 +694,7 @@
             "os": [
                 "netbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -660,6 +712,7 @@
             "os": [
                 "netbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -677,6 +730,7 @@
             "os": [
                 "openbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -694,6 +748,7 @@
             "os": [
                 "openbsd"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -711,6 +766,7 @@
             "os": [
                 "openharmony"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -728,6 +784,7 @@
             "os": [
                 "sunos"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -745,6 +802,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -762,6 +820,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -779,6 +838,7 @@
             "os": [
                 "win32"
             ],
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1088,6 +1148,288 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
+        "node_modules/@napi-rs/wasm-runtime": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+            "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1",
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            }
+        },
+        "node_modules/@oxc-project/types": {
+            "version": "0.122.0",
+            "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+            "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/Boshen"
+            }
+        },
+        "node_modules/@rolldown/binding-android-arm64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-arm64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-darwin-x64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-freebsd-x64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+            "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-gnu": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-arm64-musl": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+            "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-s390x-gnu": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-gnu": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+            "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-linux-x64-musl": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+            "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-openharmony-arm64": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+            "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-wasm32-wasi": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+            "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+            "cpu": [
+                "wasm32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "@napi-rs/wasm-runtime": "^1.1.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-arm64-msvc": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+            "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/@rolldown/binding-win32-x64-msvc": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+            "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
         "node_modules/@rolldown/pluginutils": {
             "version": "1.0.0-rc.3",
             "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
@@ -1107,7 +1449,8 @@
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-android-arm64": {
             "version": "4.60.0",
@@ -1121,7 +1464,8 @@
             "optional": true,
             "os": [
                 "android"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
             "version": "4.60.0",
@@ -1135,7 +1479,8 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-darwin-x64": {
             "version": "4.60.0",
@@ -1149,7 +1494,8 @@
             "optional": true,
             "os": [
                 "darwin"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
             "version": "4.60.0",
@@ -1163,7 +1509,8 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
             "version": "4.60.0",
@@ -1177,7 +1524,8 @@
             "optional": true,
             "os": [
                 "freebsd"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
             "version": "4.60.0",
@@ -1191,7 +1539,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
             "version": "4.60.0",
@@ -1205,7 +1554,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
             "version": "4.60.0",
@@ -1219,7 +1569,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
             "version": "4.60.0",
@@ -1233,7 +1584,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
             "version": "4.60.0",
@@ -1247,7 +1599,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
             "version": "4.60.0",
@@ -1261,7 +1614,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
             "version": "4.60.0",
@@ -1275,7 +1629,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
             "version": "4.60.0",
@@ -1289,7 +1644,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
             "version": "4.60.0",
@@ -1303,7 +1659,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
             "version": "4.60.0",
@@ -1317,7 +1674,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
             "version": "4.60.0",
@@ -1331,7 +1689,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
             "version": "4.60.0",
@@ -1345,7 +1704,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
             "version": "4.60.0",
@@ -1359,7 +1719,8 @@
             "optional": true,
             "os": [
                 "linux"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
             "version": "4.60.0",
@@ -1373,7 +1734,8 @@
             "optional": true,
             "os": [
                 "openbsd"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
             "version": "4.60.0",
@@ -1387,7 +1749,8 @@
             "optional": true,
             "os": [
                 "openharmony"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
             "version": "4.60.0",
@@ -1401,7 +1764,8 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
             "version": "4.60.0",
@@ -1415,7 +1779,8 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
             "version": "4.60.0",
@@ -1429,7 +1794,8 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
             "version": "4.60.0",
@@ -1443,7 +1809,8 @@
             "optional": true,
             "os": [
                 "win32"
-            ]
+            ],
+            "peer": true
         },
         "node_modules/@standard-schema/spec": {
             "version": "1.1.0",
@@ -1451,6 +1818,17 @@
             "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@tybys/wasm-util": {
+            "version": "0.10.1",
+            "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+            "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "tslib": "^2.4.0"
+            }
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -2521,6 +2899,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/detect-libc": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+            "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/doctrine": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -2748,6 +3136,8 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "bin": {
                 "esbuild": "bin/esbuild"
             },
@@ -4152,6 +4542,267 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/lightningcss": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "dev": true,
+            "license": "MPL-2.0",
+            "dependencies": {
+                "detect-libc": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            },
+            "optionalDependencies": {
+                "lightningcss-android-arm64": "1.32.0",
+                "lightningcss-darwin-arm64": "1.32.0",
+                "lightningcss-darwin-x64": "1.32.0",
+                "lightningcss-freebsd-x64": "1.32.0",
+                "lightningcss-linux-arm-gnueabihf": "1.32.0",
+                "lightningcss-linux-arm64-gnu": "1.32.0",
+                "lightningcss-linux-arm64-musl": "1.32.0",
+                "lightningcss-linux-x64-gnu": "1.32.0",
+                "lightningcss-linux-x64-musl": "1.32.0",
+                "lightningcss-win32-arm64-msvc": "1.32.0",
+                "lightningcss-win32-x64-msvc": "1.32.0"
+            }
+        },
+        "node_modules/lightningcss-android-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-arm64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-darwin-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-freebsd-x64": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm-gnueabihf": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-arm64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-gnu": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-linux-x64-musl": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-arm64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
+        "node_modules/lightningcss-win32-x64-msvc": {
+            "version": "1.32.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MPL-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">= 12.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/parcel"
+            }
+        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4798,12 +5449,54 @@
                 "node": ">=4"
             }
         },
+        "node_modules/rolldown": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+            "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@oxc-project/types": "=0.122.0",
+                "@rolldown/pluginutils": "1.0.0-rc.12"
+            },
+            "bin": {
+                "rolldown": "bin/cli.mjs"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            },
+            "optionalDependencies": {
+                "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+                "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+                "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+                "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+                "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+                "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+                "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+                "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+            }
+        },
+        "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+            "version": "1.0.0-rc.12",
+            "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+            "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/rollup": {
             "version": "4.60.0",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
             "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -5317,6 +6010,14 @@
                 "typescript": ">=4.8.4"
             }
         },
+        "node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "dev": true,
+            "license": "0BSD",
+            "optional": true
+        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5519,17 +6220,16 @@
             }
         },
         "node_modules/vite": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-            "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
+            "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.27.0",
-                "fdir": "^6.5.0",
-                "picomatch": "^4.0.3",
-                "postcss": "^8.5.6",
-                "rollup": "^4.43.0",
+                "lightningcss": "^1.32.0",
+                "picomatch": "^4.0.4",
+                "postcss": "^8.5.8",
+                "rolldown": "1.0.0-rc.12",
                 "tinyglobby": "^0.2.15"
             },
             "bin": {
@@ -5546,9 +6246,10 @@
             },
             "peerDependencies": {
                 "@types/node": "^20.19.0 || >=22.12.0",
+                "@vitejs/devtools": "^0.1.0",
+                "esbuild": "^0.27.0",
                 "jiti": ">=1.21.0",
                 "less": "^4.0.0",
-                "lightningcss": "^1.21.0",
                 "sass": "^1.70.0",
                 "sass-embedded": "^1.70.0",
                 "stylus": ">=0.54.8",
@@ -5561,13 +6262,16 @@
                 "@types/node": {
                     "optional": true
                 },
+                "@vitejs/devtools": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
                 "jiti": {
                     "optional": true
                 },
                 "less": {
-                    "optional": true
-                },
-                "lightningcss": {
                     "optional": true
                 },
                 "sass": {

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
         "@types/node": "^25.3.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "i18next": "^25.8.11",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-i18next": "^16.5.4",
         "typescript": "^5.9.3",
         "use-sound": "^5.0.0",
-        "use-timer": "^2.0.1",
-        "i18next": "^25.8.11",
-        "react-i18next": "^16.5.4"
+        "use-timer": "^2.0.1"
     },
     "scripts": {
         "start": "vite",
@@ -33,7 +33,7 @@
         "@vitejs/plugin-react": "^5.1.4",
         "eslint": "^9.39.1",
         "eslint-plugin-react": "^7.37.5",
-        "vite": "^7.3.1",
+        "vite": "^8.0.3",
         "vite-plugin-singlefile": "^2.3.0",
         "vitest": "^4.0.18"
     }


### PR DESCRIPTION
## 概要
- `vite` を `^7.3.1` から `^8.0.3` へメジャー更新しました（semver外更新）。

## 変更内容
- `package.json` の `vite` バージョンを更新
- `package-lock.json` を再生成

## 事前確認（変更ログ / Breaking Changes）
- Vite 8 の CHANGELOG を確認し、以下の Breaking Changes を把握:
  - `import.meta.hot.accept` の解決フォールバック削除
  - デフォルト browser target 更新
  - rolldown-vite 統合
- 本リポジトリ内で `import.meta.hot.accept` の直接利用や `build.target` の明示設定は見当たらず、今回の利用範囲では影響が限定的と判断

## 検証
- `npm test` : ✅
- `npm run build` : ✅
- 生成物ビルド成功を確認（singlefile plugin 警告は既知の deprecation warning）

## 補足
- メジャー更新ルールに従い、このPRは `vite` 単独更新です。
