### PR TITLE
chore: i18next を v26 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@types/node": "^25.3.0",
                 "@types/react": "^19.2.14",
                 "@types/react-dom": "^19.2.3",
-                "i18next": "^25.8.11",
+                "i18next": "^26.0.2",
                 "react": "^19.2.4",
                 "react-dom": "^19.2.4",
                 "react-i18next": "^16.5.4",
@@ -3539,29 +3539,29 @@
             }
         },
         "node_modules/i18next": {
-            "version": "25.8.18",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.8.18.tgz",
-            "integrity": "sha512-lzY5X83BiL5AP77+9DydbrqkQHFN9hUzWGjqjLpPcp5ZOzuu1aSoKaU3xbBLSjWx9dAzW431y+d+aogxOZaKRA==",
+            "version": "26.0.2",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.2.tgz",
+            "integrity": "sha512-WsK0SdP+7tGzsxpT+Us1s2nvOyx657DatBodaNZe4KcPTPYzkVfRKUygN69mB+sCbbnifRuKz+Ya5JRzd8DNHw==",
             "funding": [
                 {
                     "type": "individual",
-                    "url": "https://locize.com"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://locize.com/i18next.html"
+                    "url": "https://www.locize.com/i18next"
                 },
                 {
                     "type": "individual",
                     "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.locize.com"
                 }
             ],
             "license": "MIT",
             "dependencies": {
-                "@babel/runtime": "^7.28.6"
+                "@babel/runtime": "^7.29.2"
             },
             "peerDependencies": {
-                "typescript": "^5"
+                "typescript": "^5 || ^6"
             },
             "peerDependenciesMeta": {
                 "typescript": {

--- a/package.json
+++ b/package.json
@@ -6,13 +6,13 @@
         "@types/node": "^25.3.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "i18next": "^26.0.2",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-i18next": "^16.5.4",
         "typescript": "^5.9.3",
         "use-sound": "^5.0.0",
-        "use-timer": "^2.0.1",
-        "i18next": "^25.8.11",
-        "react-i18next": "^16.5.4"
+        "use-timer": "^2.0.1"
     },
     "scripts": {
         "start": "vite",


### PR DESCRIPTION
## 概要
- `i18next` を `^25.8.11` から `^26.0.2` へ更新しました（メジャーアップデート）。
- ルールに従い、メジャー更新はこの依存関係のみを1PRで実施しています。

## 変更内容
- `package.json` の `i18next` バージョン更新
- `package-lock.json` の追随更新

## Breaking Changes の確認
- 確認先: https://github.com/i18next/i18next/releases/tag/v26.0.0
- v26 の主な破壊的変更:
  - `initImmediate` 廃止（`initAsync` へ）
  - 旧 `interpolation.format` 廃止
  - `showSupportNotice` 関連廃止
  - `simplifyPluralSuffix` 廃止
- 本リポジトリの `src/i18n/configs.ts` では上記廃止オプションを使用していないことを確認済みです。

## 検証
- `npm test` ✅
- `npm run build` ✅
- GitHub Actions（`gh_pages.yml` を branch で `workflow_dispatch` 実行）✅

以上、問題なければマージお願いします。