### PR TITLE
chore: i18next を v26.0.3 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@types/node": "^25.3.0",
                 "@types/react": "^19.2.14",
                 "@types/react-dom": "^19.2.3",
-                "i18next": "^25.8.11",
+                "i18next": "^26.0.3",
                 "react": "^19.2.4",
                 "react-dom": "^19.2.4",
                 "react-i18next": "^16.5.4",
@@ -3929,9 +3929,9 @@
             }
         },
         "node_modules/i18next": {
-            "version": "25.10.9",
-            "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.9.tgz",
-            "integrity": "sha512-hQY9/bFoQKGlSKMlaCuLR8w1h5JjieqrsnZvEmj1Ja6Ec7fbyc4cTrCsY9mb9Sd8YQ/swsrKz1S9M8AcvVI70w==",
+            "version": "26.0.3",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.0.3.tgz",
+            "integrity": "sha512-1571kXINxHKY7LksWp8wP+zP0YqHSSpl/OW0Y0owFEf2H3s8gCAffWaZivcz14rMkOvn3R/psiQxVsR9t2Nafg==",
             "funding": [
                 {
                     "type": "individual",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "@types/node": "^25.3.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "i18next": "^25.8.11",
+        "i18next": "^26.0.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-i18next": "^16.5.4",


### PR DESCRIPTION
## 概要
- `i18next` を `25.10.9` から `26.0.3` へメジャー更新しました。
- semver範囲外（major）更新のため、1依存関係のみをこのPRで更新しています。

## 変更内容
- `package.json` の `i18next` を `^26.0.3` へ更新
- `package-lock.json` を更新

## 事前確認（変更ログ / Breaking Changes）
`i18next v26.0.0` のリリースノートと CHANGELOG を確認しました。
主な Breaking Changes:
- `initImmediate` 廃止（`initAsync` を利用）
- 旧 `interpolation.format` 廃止（Formatter API利用へ）
- `showSupportNotice` 廃止
- `simplifyPluralSuffix` 廃止

本リポジトリでは上記オプションを利用していないため、影響は限定的と判断しました。

## 検証
- `npm test` ✅
- `npm run build` ✅

CI成功後にマージ予定です。