### PR TITLE
react-i18next を v17 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "i18next": "^26.0.3",
                 "react": "^19.2.4",
                 "react-dom": "^19.2.4",
-                "react-i18next": "^16.5.4",
+                "react-i18next": "^17.0.4",
                 "typescript": "^5.9.3",
                 "use-sound": "^5.0.0",
                 "use-timer": "^2.0.1"
@@ -5328,9 +5328,9 @@
             }
         },
         "node_modules/react-i18next": {
-            "version": "16.6.6",
-            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.6.6.tgz",
-            "integrity": "sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==",
+            "version": "17.0.4",
+            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.4.tgz",
+            "integrity": "sha512-hQipmK4EF0y6RO6tt6WuqnmWpWYEXmQUUzecmMBuNsIgYd3smXcG4GtYPWhvgxn0pqMOItKlEO8H24HCs5hc3g==",
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.29.2",
@@ -5338,7 +5338,7 @@
                 "use-sync-external-store": "^1.6.0"
             },
             "peerDependencies": {
-                "i18next": ">= 25.10.9",
+                "i18next": ">= 26.0.1",
                 "react": ">= 16.8.0",
                 "typescript": "^5 || ^6"
             },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "i18next": "^26.0.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "react-i18next": "^16.5.4",
+        "react-i18next": "^17.0.4",
         "typescript": "^5.9.3",
         "use-sound": "^5.0.0",
         "use-timer": "^2.0.1"


### PR DESCRIPTION
## 概要
- `react-i18next` を `^16.5.4` から `^17.0.4` へ更新しました
- semver 範囲外の major 更新ですが、今回の breaking change は `<Trans>` の自動キー生成周りで、このリポジトリでは `useTranslation()` のみを使っており影響範囲は限定的と判断しました

## 確認したこと
- 変更ログ確認: react-i18next 17.0.0 の breaking change は `<Trans>` の HTML ノード保持時の自動キー生成に関する修正
- コード確認: `src` / `tests` 内で `<Trans>` 利用はなく、`useTranslation()` のみ利用
- `npm test`
- `npm run build`

## 補足
- 依存 peer 条件の `i18next >= 26.0.1` は既存の `i18next ^26.0.3` で満たしています
- GitHub Project: https://github.com/users/kurehajime/projects/2/
