### PR TITLE
Dependabot を週次の multi-ecosystem グループにまとめる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,27 @@
 version: 2
+
+multi-ecosystem-groups:
+  dependency-updates:
+    schedule:
+      interval: "weekly"
+
 updates:
   - package-ecosystem: "npm"
     directory: "/"
-    schedule:
-      interval: "weekly"
+    patterns: ["*"]
+    multi-ecosystem-group: "dependency-updates"
     cooldown:
       default-days: 2
+    groups:
+      all-npm-security-updates:
+        applies-to: "security-updates"
+        patterns: ["*"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    patterns: ["*"]
+    multi-ecosystem-group: "dependency-updates"
+    groups:
+      all-github-actions-security-updates:
+        applies-to: "security-updates"
+        patterns: ["*"]


### PR DESCRIPTION
### Motivation
- Dependabot の PR をできるだけまとめて一括管理し、通知・レビューのオーバーヘッドを下げるために設定を変更する意図です。

### Description
- `.github/dependabot.yml` に `multi-ecosystem-groups.dependency-updates` を追加して週次スケジュールに設定しました。
- `npm` のエントリをワイルドカードパターン `patterns: ["*"]` として `multi-ecosystem-group: "dependency-updates"` に参加させ、既存の `cooldown.default-days: 2` は維持しました。
- `npm` 向けのセキュリティ更新を `all-npm-security-updates` グループでワイルドカードによりまとめる設定を追加しました。
- `github-actions` エコシステムを同じ `dependency-updates` グループに追加し、`all-github-actions-security-updates` グループをセキュリティ更新のために追加しました。

### Testing
- `ruby -e 'require "yaml"; data = YAML.load_file(".github/dependabot.yml"); abort("bad version") unless data["version"] == 2; abort("missing multi-ecosystem-groups") unless data["multi-ecosystem-groups"]; abort("bad updates") unless data["updates"].is_a?(Array) && data["updates"].size == 2; puts "dependabot.yml is valid YAML"'` を実行して成功しました。
- `git diff --check` を実行して問題がないことを確認しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b820fa148326b8e7a2898f280b27)